### PR TITLE
Attack and Damage test

### DIFF
--- a/BlackPlanet/Assets/Scripts/BossMonster.cs
+++ b/BlackPlanet/Assets/Scripts/BossMonster.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BossMonster : MonoBehaviour, IStat, IDamageable
+{
+    public int HealthPoint { get; set; }
+    public int StrikingPower { get; set; }
+
+    public void SetStat()
+    {
+        HealthPoint = 100;
+        StrikingPower = 10;
+    }
+
+    public void Damage(int strikingPower, DamageType damageType)
+    { 
+        switch (damageType)
+        {
+            case DamageType.Attack:
+                HealthPoint -= strikingPower;
+                break;
+            case DamageType.SpeicalAttack:
+                HealthPoint -= strikingPower * 2;
+                break;
+        }
+    }
+
+    public void Death()
+    { 
+        Debug.Log("보스가 사망했습니다. 게임승리");
+    }
+     
+}

--- a/BlackPlanet/Assets/Scripts/BossMonster.cs.meta
+++ b/BlackPlanet/Assets/Scripts/BossMonster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b55a02d88668e248aebda08051821d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BlackPlanet/Assets/Scripts/DamageType.cs
+++ b/BlackPlanet/Assets/Scripts/DamageType.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum DamageType
+{
+    Attack,
+    SpeicalAttack
+}

--- a/BlackPlanet/Assets/Scripts/DamageType.cs.meta
+++ b/BlackPlanet/Assets/Scripts/DamageType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3dd0b38c69f02ae42a7f115b3d88340d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BlackPlanet/Assets/Scripts/GameManager.cs
+++ b/BlackPlanet/Assets/Scripts/GameManager.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{ 
+    public Player player;
+    public BabyMonster babyMonster;
+    public DevilMonster devilMonster;
+    public BossMonster bossMonster;
+   
+    private void Start()
+    {
+        player = gameObject.AddComponent<Player>();
+        babyMonster = gameObject.AddComponent<BabyMonster>();
+        devilMonster = gameObject.AddComponent<DevilMonster>();
+        bossMonster = gameObject.AddComponent<BossMonster>(); 
+    }
+
+    public void SetStat()
+    {
+        player.SetStat();
+        bossMonster.SetStat();
+    }
+ 
+    public void BossAtack(DamageType damageType)
+    {
+        if (bossMonster.HealthPoint > 0)
+            player.Damage(bossMonster.StrikingPower, damageType);
+      
+        if (player.HealthPoint <= 0)
+            player.Death();
+
+        PrintHealthPoint();
+    }
+ 
+    public void PlayerAttack(DamageType damageType)
+    {
+        if (player.HealthPoint > 0)
+            bossMonster.Damage(player.StrikingPower, damageType);
+
+        if (bossMonster.HealthPoint <= 0)
+            bossMonster.Death();
+
+        PrintHealthPoint();
+    }
+     
+    public void PrintHealthPoint()
+    {
+        Debug.Log("Player health:" + player.HealthPoint);
+        Debug.Log("Boss health:" + bossMonster.HealthPoint);
+    }
+
+}
+

--- a/BlackPlanet/Assets/Scripts/GameManager.cs.meta
+++ b/BlackPlanet/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85ee5258d4c9eeb4bb129bb6972b77c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BlackPlanet/Assets/Scripts/Interface/IDamageable.cs
+++ b/BlackPlanet/Assets/Scripts/Interface/IDamageable.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public interface IDamageable
+{
+    public void Damage(int strikingPower, DamageType damageType);
+     
+}

--- a/BlackPlanet/Assets/Scripts/Interface/IDamageable.cs.meta
+++ b/BlackPlanet/Assets/Scripts/Interface/IDamageable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b091098afecc3b6489f62256ec4d4089
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BlackPlanet/Assets/Scripts/Interface/IStat.cs
+++ b/BlackPlanet/Assets/Scripts/Interface/IStat.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+ 
+public interface IStat  
+{
+    public int HealthPoint { get; set; }
+    public int StrikingPower { get; set; }
+
+
+    public void Death();
+   
+}

--- a/BlackPlanet/Assets/Scripts/Interface/IStat.cs.meta
+++ b/BlackPlanet/Assets/Scripts/Interface/IStat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 965dd86a3996f9449a7a6a355420d2ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BlackPlanet/Assets/Scripts/Player.cs
+++ b/BlackPlanet/Assets/Scripts/Player.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+using System;
+
+public class Player : MonoBehaviour, IStat, IDamageable
+{
+    public int HealthPoint { get; set; }
+    public int StrikingPower { get; set; }
+
+    public void SetStat()
+    {
+        HealthPoint = 20;
+        StrikingPower = 1;
+    }
+     
+    public void Damage(int strikingPower, DamageType damageType)
+    {
+        switch (damageType)
+        {
+            case DamageType.Attack:
+                HealthPoint -= strikingPower;
+                break;
+            case DamageType.SpeicalAttack:
+                HealthPoint -= strikingPower * 2;
+                break;
+        }
+    }
+
+     
+    public void Death()
+    {
+        Debug.Log("플레이어가 사망했습니다. 게임종료");
+        UnityEditor.EditorApplication.isPlaying = false;
+    }
+}

--- a/BlackPlanet/Assets/Scripts/Player.cs.meta
+++ b/BlackPlanet/Assets/Scripts/Player.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90299af5a2846b643b6c0e4b65d8bbc2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BlackPlanet/Assets/Tests/DamageTest.cs
+++ b/BlackPlanet/Assets/Tests/DamageTest.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class DamageTest
+{ 
+    
+    [Test]
+    public void AttackToBoss()
+    {
+        GameManager gameManager = GameObject.Find("GameManager").GetComponent<GameManager>();
+        Assert.IsNotNull(gameManager);
+         
+        gameManager.SetStat();
+        gameManager.PrintHealthPoint();
+
+        int originBossHP = gameManager.bossMonster.HealthPoint;
+        int expectedBossHP = originBossHP - gameManager.player.StrikingPower;
+         
+        gameManager.PlayerAttack(DamageType.Attack);
+ 
+        Assert.IsTrue(gameManager.bossMonster.HealthPoint == expectedBossHP);
+    }
+
+
+    [Test]
+    public void AttackToPlayer()
+    {
+        GameManager gameManager = GameObject.Find("GameManager").GetComponent<GameManager>();
+
+        Assert.IsNotNull(gameManager);
+
+        gameManager.SetStat();
+        gameManager.PrintHealthPoint();
+         
+        int originPlayerHP = gameManager.player.HealthPoint;
+        int expectedPlayerHP = originPlayerHP - gameManager.bossMonster.StrikingPower;
+
+        gameManager.BossAtack(DamageType.Attack);
+     
+        Assert.IsTrue(gameManager.player.HealthPoint == expectedPlayerHP);
+    }
+     
+}

--- a/BlackPlanet/Assets/Tests/DamageTest.cs.meta
+++ b/BlackPlanet/Assets/Tests/DamageTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f069cb0bba2301d44b156469594486da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Requirements
 몬스터가 플레이어에게 어택을 하면 플레이어의 HP가 감소
 플레이어가 몬스터에게 어택을하면 몬스터의 HP가 감소
 　

## Design

### Interface
**IStat**
   +int HealthPoint 
   +int StrikingPower  
   +Death 
 
**IDamageable**
   +Damage (int strikingPower, DamageType damageType) 
 　

### Class
**Player**
   +HealthPoint
   +StrikingPower
   +Damage (int strikingPower, DamageType damageType)
   +Death 
 
**BossMonster**
   +HealthPoint
   +StrikingPower
   +Damage (int strikingPower, DamageType damageType)
   +Death 
 
 **GameManager**
    +Player player;
    +BossMonster bossMonster;
    +SetStat 
    +BossAtack (DamageType damageType)
   
 　

 ## Test  
     
 //Arrange
GameManager gameManager = GameObject.Find("GameManager").GetComponent<GameManager>();
   
 //Assert1 
Assert.IsNotNull(gameManager);

 //Action - 플레이어가 보스몬스터를 공격 
gameManager.PlayerAttack(DamageType.Attack);

 //Assert2 -  몬스터의 HP가 플레이어의 strikingPower만큼 감소했는지 확인
Assert.IsTrue(gameManager.bossMonster.HealthPoint == expectedBossHP);
　

## 참고사항 
테스트 코드를 짜다보니 설계를 재차 확인하게 되는 것 같습니다. 

고민 중인 것이 있습니다.
- 몬스터 타입을 두고, 몬스터 3종 (Boss, baby, devil)을 관리하는 건 어떨지
- 게임 매니저에서 각각 어택을 해주는게 어색하다고 느껴지는데, 어택 방식 개선이 필요하진 않을지